### PR TITLE
Fix format field from "Âµs" to "µs"

### DIFF
--- a/carbon-c-relay/carbon-c-relay.json
+++ b/carbon-c-relay/carbon-c-relay.json
@@ -282,7 +282,7 @@
           "datasource": "${DS_GRAPHITE}",
           "editable": true,
           "error": false,
-          "format": "Âµs",
+          "format": "µs",
           "gauge": {
             "maxValue": 100,
             "minValue": 0,
@@ -1025,7 +1025,7 @@
           },
           "yaxes": [
             {
-              "format": "Âµs",
+              "format": "µs",
               "label": "",
               "logBase": 1,
               "max": null,
@@ -1253,7 +1253,7 @@
           },
           "yaxes": [
             {
-              "format": "Âµs",
+              "format": "µs",
               "label": "",
               "logBase": 1,
               "max": null,
@@ -1481,7 +1481,7 @@
           },
           "yaxes": [
             {
-              "format": "Âµs",
+              "format": "µs",
               "label": "",
               "logBase": 1,
               "max": null,


### PR DESCRIPTION
The dashboard sets the format field to "Âµs" which is interpreted as "+" when the dashboard is imported into Grafana. This breaks all of the wallTime graphs.